### PR TITLE
Optional Webstore Link Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Set the OpenTok session  (object).| `session` |`true`
 Set the screen container (string). | `screenSharingContainer`  |`false`
 Set the Common layer API (object). | `accPack` |`false`
 Set the ID of the Chrome extension (string). | `extensionID` |`false`
+Append a link tag for Chrome Web Store inline install (boolean) (defaults to `true`). | `appendWebStoreLink` |`false`
 Set the download path for the FireFox extension (string). | `extentionPathFF` |`false`
 Using screen sharing with the annotation accelerator pack.| `annotation` |`false`
 If using annotation, should we use an external window.| `externalWindow` |`false`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-screen-sharing",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "OpenTok screen sharing accelerator pack",
   "main": "dist/opentok-screen-sharing.js",
   "directories": {

--- a/src/opentok-screen-sharing.js
+++ b/src/opentok-screen-sharing.js
@@ -417,7 +417,9 @@
     _session = _.property('session')(options);
     _accPack = _.property('accPack')(options);
 
-    _validateExtension(_.property('extensionID')(options), _.property('extensionPathFF')(options), _.property('appendWebStoreLink')(options));
+    var appendLink = options.appendWebStoreLink === undefined ? true : options.appendWebStoreLink;
+
+    _validateExtension(_.property('extensionID')(options), _.property('extensionPathFF')(options), appendLink);
   };
 
   /**

--- a/src/opentok-screen-sharing.js
+++ b/src/opentok-screen-sharing.js
@@ -390,17 +390,18 @@
 
   };
 
-  var _validateExtension = function (extensionID) {
+  var _validateExtension = function (extensionID, extensionPathFF, appendWebStoreLink) {
 
     if (OT.$.browser() === 'Chrome') {
       if (!extensionID || !extensionID.length) {
         throw new Error('Error starting the screensharing. Chrome extensionID required');
       } else {
-        $('<link/>', {
-          rel: 'chrome-webstore-item',
-          href: ['https://chrome.google.com/webstore/detail/', extensionID].join('')
-        }).appendTo('head');
-
+        if (appendWebStoreLink) {
+          $('<link/>', {
+            rel: 'chrome-webstore-item',
+            href: ['https://chrome.google.com/webstore/detail/', extensionID].join('')
+          }).appendTo('head');
+        }
         OT.registerScreenSharingExtension('chrome', extensionID, 2);
       }
     }
@@ -416,7 +417,7 @@
     _session = _.property('session')(options);
     _accPack = _.property('accPack')(options);
 
-    _validateExtension(_.property('extensionID')(options), _.property('extensionPathFF')(options));
+    _validateExtension(_.property('extensionID')(options), _.property('extensionPathFF')(options), _.property('appendWebStoreLink')(options));
   };
 
   /**
@@ -426,6 +427,7 @@
    * @param {String} options.session
    * @param {Object} [options.accPack]
    * @param {String} [options.extensionID]
+   * @param {String} [options.appendWebStoreLink]
    * @param {String} [options.extentionPathFF]
    * @param {String} [options.screensharingParent]
    * @param {String | Function} [options.screensharingContainer]
@@ -443,6 +445,7 @@
       'externalWindow',
       'extensionURL',
       'extensionID',
+      'appendWebStoreLink',
       'extensionPathFF',
       'screenSharingContainer',
       'screenSharingParent',
@@ -458,6 +461,7 @@
       screenSharingParent: '#videoContainer',
       screenSharingContainer: document.getElementById('videoHolderSharedScreen'),
       controlsContainer: '#feedControls',
+      appendWebStoreLink: true,
       appendControl: true,
     }));
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #___.

## What's in this pull request?

Add `appendWebStoreLink` parameter to `@constructor` options hash to allow not appending a Chrome web store inline install link to the HTML.  This parameter is set to `true` by default, but we want to let users opt out.
