### PR TITLE
Allow firefox screen sharing without extension from 52.0

### DIFF
--- a/src/detect-browser.js
+++ b/src/detect-browser.js
@@ -37,4 +37,10 @@ function detectBrowser() {
   }
   // Default fallthrough: not supported.
   return 'unsupported browser';
-}
+};
+
+function firefoxExtensionRequired() {
+  var match = navigator.userAgent.match(/(?:firefox|iceweasel|fxios)[ \/](\d+(\.\d+)?)/i);
+  var version = (match && match.length > 1 && match[1]) || '';
+  return version < "52.0";
+};

--- a/src/detect-browser.js
+++ b/src/detect-browser.js
@@ -42,5 +42,5 @@ function detectBrowser() {
 function firefoxExtensionRequired() {
   var match = navigator.userAgent.match(/(?:firefox|iceweasel|fxios)[ \/](\d+(\.\d+)?)/i);
   var version = (match && match.length > 1 && match[1]) || '';
-  return version < "52.0";
+  return version < '52.0';
 };

--- a/src/opentok-screen-sharing.js
+++ b/src/opentok-screen-sharing.js
@@ -281,7 +281,7 @@
 
     OT.checkScreenSharingCapability(function (response) {
       if (!response.supported || !response.extensionRegistered) {
-        if (detectBrowser() === 'Firefox' && response.extensionInstalled) {
+        if (detectBrowser() === 'Firefox' && (response.extensionInstalled || !firefoxExtensionRequired())) {
           deferred.resolve();
         } else if (detectBrowser() === 'Firefox' && !response.extensionInstalled) {
           $('#dialog-form-ff').toggle();


### PR DESCRIPTION
Fixes #21  