### PR TITLE
[ECO-3794] Fix checkScreenSharingCapability process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 --------------------------------------
 
+#### [1.0.33]
+
+[FIXED] Fix OT.checkScreenSharingCapability
+
 #### [1.0.32]
 
 [UPDATED] screenDialogsExtensions option

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-screen-sharing",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "OpenTok screen sharing accelerator pack",
   "main": "dist/opentok-screen-sharing.js",
   "directories": {

--- a/src/opentok-screen-sharing.js
+++ b/src/opentok-screen-sharing.js
@@ -283,19 +283,21 @@
     }
 
     OT.checkScreenSharingCapability(function (response) {
-      if (!response.supported || !response.extensionRegistered) {
-        if (detectBrowser() === 'Firefox' && (response.extensionInstalled || !firefoxExtensionRequired())) {
-          deferred.resolve();
-        } else if (detectBrowser() === 'Firefox' && !response.extensionInstalled) {
-          $('#dialog-form-ff').toggle();
-          deferred.reject('screensharing extension not installed');
+      if (!response.supported || response.extensionRegistered === false) {
+        alert('This browser does not support screen sharing! Please use Chrome, Firefox or IE!');
+        deferred.reject('browser support not available');
+      } else if (response.extensionInstalled === false) {
+        if (detectBrowser() === 'Firefox') {
+          if (!firefoxExtensionRequired()) {
+            deferred.resolve();
+          } else {
+            $('#dialog-form-ff').toggle();
+            deferred.reject('screensharing extension not installed');
+          }
         } else {
-          alert('This browser does not support screen sharing! Please use Chrome, Firefox or IE!');
-          deferred.reject('browser support not available');
+          $('#dialog-form-chrome').toggle();
+          deferred.reject('screensharing extension not installed');
         }
-      } else if (!response.extensionInstalled) {
-        $('#dialog-form-chrome').toggle();
-        deferred.reject('screensharing extension not installed');
       } else {
         deferred.resolve();
       }
@@ -348,13 +350,7 @@
 
     /** Handlers for screensharing extension modal */
     $('#btn-install-plugin-chrome').on('click', function () {
-      chrome.webstore.install(['https://chrome.google.com/webstore/detail/', _this.extensionID].join(''),
-        function (success) {
-          console.log('success', success);
-        },
-        function (error) {
-          console.log('error', error);
-        });
+      window.open(['https://chrome.google.com/webstore/detail/', _this.extensionID].join(''), '_blank');
       $('#dialog-form-chrome').toggle();
     });
 


### PR DESCRIPTION
This PR fixes the screen sharing in Chrome that was failing because of an outdated way to validate if the browser supports or not screen sharing.
