### PR TITLE
Adding optional publisher properties on start API

### DIFF
--- a/src/opentok-screen-sharing.js
+++ b/src/opentok-screen-sharing.js
@@ -157,7 +157,7 @@
    * element so that we can pass it to the initPublisher function.
    * @returns {promise} < Resolve: [Object] Container element for annotation in external window >
    */
-  var _initPublisher = function (props) {
+  var _initPublisher = function (publisherOptions) {
 
     var createPublisher = function (publisherDiv) {
 
@@ -177,8 +177,10 @@
         _this.localScreenProperties ||
         _defaultScreenProperties;
 
-      if (props) {
-        Object.assign(properties, props);
+      if (publisherOptions) {
+       var properties = Object.assign(
+         {}, _this.localScreenProperties || _defaultScreenProperties, publisherOptions
+       );
       }
       _this.publisher = OT.initPublisher(container, properties, function (error) {
         if (error) {
@@ -308,11 +310,15 @@
     return deferred.promise();
 
   };
-
-  var start = function (props) {
+  /**
+   * Accepts custom properties as a parameters
+   * @param {Object} publisherOptions
+   * @param null
+   */
+  var start = function (publisherOptions) {
     _log(_logEventData.actionStart, _logEventData.variationAttempt);
     extensionAvailable(_this.extensionID, _this.extensionPathFF)
-      .then(_initPublisher(props))
+      .then(_initPublisher(publisherOptions))
       .then(_publish)
       .fail(function (error) {
         console.log('Error starting screensharing: ', error);

--- a/src/opentok-screen-sharing.js
+++ b/src/opentok-screen-sharing.js
@@ -173,15 +173,9 @@
       }
 
       var container = getContainer();
-      var properties =
-        _this.localScreenProperties ||
-        _defaultScreenProperties;
+      
+      var properties = Object.assign({}, _this.localScreenProperties || _defaultScreenProperties, publisherOptions);
 
-      if (publisherOptions) {
-       var properties = Object.assign(
-         {}, _this.localScreenProperties || _defaultScreenProperties, publisherOptions
-       );
-      }
       _this.publisher = OT.initPublisher(container, properties, function (error) {
         if (error) {
           _triggerEvent('screenSharingError', error);
@@ -311,9 +305,7 @@
 
   };
   /**
-   * Accepts custom properties as a parameters
-   * @param {Object} publisherOptions
-   * @param null
+   * @param {Object} [publisherOptions]  - Properties for the screen sharing publisher.
    */
   var start = function (publisherOptions) {
     _log(_logEventData.actionStart, _logEventData.variationAttempt);

--- a/src/opentok-screen-sharing.js
+++ b/src/opentok-screen-sharing.js
@@ -157,7 +157,7 @@
    * element so that we can pass it to the initPublisher function.
    * @returns {promise} < Resolve: [Object] Container element for annotation in external window >
    */
-  var _initPublisher = function () {
+  var _initPublisher = function (props) {
 
     var createPublisher = function (publisherDiv) {
 
@@ -175,9 +175,11 @@
       var container = getContainer();
       var properties =
         _this.localScreenProperties ||
-        _this.localScreenProperties ||
         _defaultScreenProperties;
 
+      if (props) {
+        Object.assign(properties, props);
+      }
       _this.publisher = OT.initPublisher(container, properties, function (error) {
         if (error) {
           _triggerEvent('screenSharingError', error);
@@ -307,10 +309,10 @@
 
   };
 
-  var start = function () {
+  var start = function (props) {
     _log(_logEventData.actionStart, _logEventData.variationAttempt);
     extensionAvailable(_this.extensionID, _this.extensionPathFF)
-      .then(_initPublisher)
+      .then(_initPublisher(props))
       .then(_publish)
       .fail(function (error) {
         console.log('Error starting screensharing: ', error);


### PR DESCRIPTION
- Removed duplicated evaluation logic.

#### This fixes issue #36 _.

## What's in this pull request?

> User can now pass custom properties before initPublisher while screensharing.
